### PR TITLE
add absolute function

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -414,6 +414,16 @@ class Money implements Serializable, JsonSerializable
     }
 
     /**
+     * @return \Keios\MoneyRight\Money
+     */
+    public function abs()
+    {
+        $amount = $this->isNegative() ? substr($this->amount, 1): $this->amount;
+        
+        return new Money($amount, $this->currency);
+    }
+
+    /**
      * @return bool
      */
     public function isZero()

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -220,6 +220,19 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function testAbsYieldsCorrectResults()
+    {
+        $this->money1 = new Money('2.3456789', $this->currency1);
+        $this->money2 = new Money('2.3456789', $this->currency1);
+        $this->money3 = new Money('-2.3456789', $this->currency1);
+
+        $this->assertTrue($this->money1->equals($this->money2->abs()));
+        $this->assertTrue($this->money1->equals($this->money3->abs()));
+    }
+
+    /**
+     * @test
+     */
     public function testAddingInstancesWithSameCurrencyYieldsCorrectResults()
     {
         $this->money1 = new Money('2.3456789', $this->currency1); // 2.3457


### PR DESCRIPTION
Hey,

I needed a way to find the absolute for a Money value.
I was doing it in my code like so:

```
if ($amount->isNegative()) {
    $amount = $amount->multiply(-1, Money::ROUND_HALF_UP, true);
}
```

Any interest in adding an `absolute` function to the library?

It seems we can shortcut the calculation, by just trimming off the `-` if necessary.

Thanks.
